### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/url-sheriff"><img src="https://badgen.net/npm/v/url-sheriff" alt="npm version"/></a>
   <a href="https://www.npmjs.com/package/url-sheriff"><img src="https://badgen.net/npm/license/url-sheriff" alt="license"/></a>
   <a href="https://www.npmjs.com/package/url-sheriff"><img src="https://badgen.net/npm/dt/url-sheriff" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/url-sheriff/actions?workflow=CI"><img src="https://github.com/lirantal/url-sheriff/workflows/CI/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/url-sheriff/actions/workflows/ci.yml"><img src="https://github.com/lirantal/url-sheriff/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://app.codecov.io/gh/lirantal/url-sheriff"><img src="https://badgen.net/codecov/c/github/lirantal/url-sheriff" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README currently points to the unpinned workflow URL, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.