### PR TITLE
chore(automerge): remove check_suite if-condition on automerge job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,9 +19,6 @@ on:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name != 'check_suite' ||
-      github.event.check_suite.pull_requests[0] != null
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Removes the `if:` block on the `automerge` job that conditioned on `check_suite` events. The condition was a workaround for an older github-actions behavior and is no longer necessary — the workflow now runs unconditionally on its triggering events.

```diff
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name != 'check_suite' ||
-      github.event.check_suite.pull_requests[0] != null
     permissions:
       contents: write
       pull-requests: write
```