### PR TITLE
chore: replace deprecated tsconfig baseUrl with paths + types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,17 @@
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "target": "ES2022",
-    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
     "noEmit": true,
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION
TypeScript 6 started failing the CI build with `TS5101` because `compilerOptions.baseUrl` is now deprecated and scheduled to stop working in TypeScript 7. This change removes the deprecated setting and migrates the project to an explicit alias-based configuration.

- **Problem**
  - `tsc` fails on `tsconfig.json` due to deprecated `baseUrl`.
  - The repo was not relying on root-based imports today, but the deprecated setting still blocked the build after the TypeScript upgrade.

- **Config migration**
  - remove `compilerOptions.baseUrl`
  - add an explicit alias mapping via `compilerOptions.paths`
  - keep module resolution aligned with the current Node/ESM setup

- **Type resolution**
  - add `types: ["node"]` so Node built-ins continue resolving cleanly under the updated config

- **Result**
  - the project no longer depends on deprecated `baseUrl` behavior
  - future internal imports can use an explicit alias instead of implicit root lookup

```json
{
  "compilerOptions": {
    "types": ["node"],
    "paths": {
      "@/*": ["./src/*"]
    }
  }
}
```
