### PR TITLE
fix: resolve IPv6 records with custom DNS resolvers

### DIFF
--- a/__tests__/customResolver.test.ts
+++ b/__tests__/customResolver.test.ts
@@ -3,6 +3,12 @@ import assert from 'node:assert'
 import URLSheriff from '../src/main.ts'
 import { Resolver } from 'node:dns/promises'
 
+function createDnsError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`DNS lookup failed with ${code}`) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
 describe('DNS Resolver Tests', () => {
   beforeEach(() => {
     mock.reset()
@@ -11,8 +17,12 @@ describe('DNS Resolver Tests', () => {
   test('Providing custom DNS resolver servers uses the custom resolver for DNS lookups', async (t) => {
     const customResolvers = ['1.1.1.1', '8.8.8.8']
 
-    // Mock the Resolver class and its setServers method
+    // Mock the Resolver class and its DNS methods
     const resolverMock = t.mock.method(Resolver.prototype, 'setServers')
+    const resolve4Mock = t.mock.method(Resolver.prototype, 'resolve4', async () => ['93.184.216.34'])
+    const resolve6Mock = t.mock.method(Resolver.prototype, 'resolve6', async () => {
+      throw createDnsError('ENODATA')
+    })
 
     const sheriff = new URLSheriff({
       dnsResolvers: customResolvers
@@ -24,6 +34,8 @@ describe('DNS Resolver Tests', () => {
     // Verify that Resolver.prototype.setServers was called with the custom resolvers
     assert.strictEqual(resolverMock.mock.callCount(), 1, 'setServers should be called once')
     assert.deepStrictEqual(resolverMock.mock.calls[0].arguments[0], customResolvers, 'setServers should be called with custom resolvers')
+    assert.strictEqual(resolve4Mock.mock.callCount(), 1, 'resolve4 should be called once')
+    assert.strictEqual(resolve6Mock.mock.callCount(), 1, 'resolve6 should be called once')
   })
 
   test('When no custom DNS resolvers are provided, the default lookup should be used', async (t) => {
@@ -47,6 +59,55 @@ describe('DNS Resolver Tests', () => {
         message: 'DNS resolver is not defined'
       }
     )
+  })
+
+  test('Custom DNS resolvers should return IPv4 and IPv6 addresses', async (t) => {
+    const resolve4Mock = t.mock.method(Resolver.prototype, 'resolve4', async () => ['93.184.216.34'])
+    const resolve6Mock = t.mock.method(Resolver.prototype, 'resolve6', async () => ['2606:2800:220:1:248:1893:25c8:1946'])
+
+    const sheriff = new URLSheriff({
+      dnsResolvers: ['1.1.1.1']
+    })
+
+    const addresses = await sheriff.resolveHostnameViaServers('example.com')
+
+    assert.deepStrictEqual(addresses, ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
+    assert.strictEqual(resolve4Mock.mock.callCount(), 1, 'resolve4 should be called once')
+    assert.strictEqual(resolve6Mock.mock.callCount(), 1, 'resolve6 should be called once')
+  })
+
+  test('Custom DNS resolvers should reject IPv6-only private hostnames as private', async (t) => {
+    t.mock.method(Resolver.prototype, 'resolve4', async () => {
+      throw createDnsError('ENODATA')
+    })
+    const resolve6Mock = t.mock.method(Resolver.prototype, 'resolve6', async () => ['::1'])
+
+    const sheriff = new URLSheriff({
+      dnsResolvers: ['1.1.1.1']
+    })
+
+    await assert.rejects(
+      sheriff.isSafeURL('https://ipv6-private.example'),
+      {
+        name: 'Error',
+        message: 'URL uses a private hostname'
+      }
+    )
+    assert.strictEqual(resolve6Mock.mock.callCount(), 1, 'resolve6 should be called once')
+  })
+
+  test('Custom DNS resolvers should allow public IPv6-only hostnames', async (t) => {
+    t.mock.method(Resolver.prototype, 'resolve4', async () => {
+      throw createDnsError('ENODATA')
+    })
+    t.mock.method(Resolver.prototype, 'resolve6', async () => ['2606:2800:220:1:248:1893:25c8:1946'])
+
+    const sheriff = new URLSheriff({
+      dnsResolvers: ['1.1.1.1']
+    })
+
+    const isSafe = await sheriff.isSafeURL('https://ipv6-public.example')
+    assert.strictEqual(isSafe, true)
   })
 
   test('Should handle invalid DNS resolver addresses appropriately', async (t) => {

--- a/__tests__/isSafeURL.sanity.test.ts
+++ b/__tests__/isSafeURL.sanity.test.ts
@@ -56,6 +56,25 @@ describe('SSRF isSafeURL Sanity suite #1', () => {
     assert.strictEqual(isSafe, true);
   })
 
+  test('If a URL uses a private IPv6 literal, an exception is thrown without DNS lookup', async (t) => {
+    const sheriff = new URLSheriff({})
+    const hostnameLookupMock = t.mock.method(sheriff, 'hostnameLookup', async () => {
+      assert.fail('IPv6 literals should be validated as IP addresses without DNS lookup')
+    })
+
+    for (const url of ['http://[::1]/', 'http://[::ffff:127.0.0.1]/', 'http://[fc00::1]/']) {
+      await assert.rejects(
+        sheriff.isSafeURL(url),
+        {
+          name: 'Error',
+          message: 'URL uses a private hostname'
+        }
+      )
+    }
+
+    assert.strictEqual(hostnameLookupMock.mock.callCount(), 0, 'hostnameLookup should not be called for IPv6 literals')
+  })
+
   test.skip('If a URL uses an IPv4 Mapped address via IPv6 that turns out to be reserved, throw the exception', async (t) => {
     // this doesn't yet pass because it the ipv6 address doesn't get passed through new URL() anyway
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,22 @@ import { debuglog } from 'node:util'
 // Initialize debug logger for 'url-sheriff' namespace
 const debug = debuglog('url-sheriff')
 
+function normalizeHostname(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1)
+  }
+
+  return hostname
+}
+
+function isDnsNoRecordError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('code' in error)) {
+    return false
+  }
+
+  return error.code === 'ENODATA' || error.code === 'ENOTFOUND'
+}
+
 interface URLSheriffConfig {
   dnsResolvers?: string[]
   allowList?: Array<string | RegExp>
@@ -114,7 +130,7 @@ export default class URLSheriff {
     debug('Checking if URL is safe: %s', typeof url === 'string' ? url : url.href)
     
     const parsedUrl = this.#getParsedURL(url)
-    const hostname = parsedUrl.hostname
+    const hostname = normalizeHostname(parsedUrl.hostname)
     const scheme = parsedUrl.protocol.replace(':', '')
     
     debug('Extracted hostname: %s, scheme: %s', hostname, scheme)
@@ -231,7 +247,33 @@ export default class URLSheriff {
     }
     
     try {
-      const ipAddressList: string[] = await this.#resolver.resolve4(hostname)
+      const [ipv4Result, ipv6Result] = await Promise.allSettled([
+        this.#resolver.resolve4(hostname),
+        this.#resolver.resolve6(hostname)
+      ])
+
+      const unexpectedError = [ipv4Result, ipv6Result].find(result => {
+        return result.status === 'rejected' && !isDnsNoRecordError(result.reason)
+      })
+      if (unexpectedError?.status === 'rejected') {
+        throw unexpectedError.reason
+      }
+
+      const ipAddressList: string[] = [ipv4Result, ipv6Result].flatMap(result => {
+        return result.status === 'fulfilled' ? result.value : []
+      })
+      if (ipAddressList.length === 0) {
+        const dnsError = [ipv4Result, ipv6Result].find(result => {
+          return result.status === 'rejected'
+        })
+
+        if (dnsError?.status === 'rejected') {
+          throw dnsError.reason
+        }
+
+        throw new Error(`Could not resolve hostname: ${hostname}`)
+      }
+
       return ipAddressList
     } catch (error) {
       debug('Error resolving hostname %s with custom resolvers: %O', hostname, error)


### PR DESCRIPTION
## Summary
- Resolve both A and AAAA records when custom `dnsResolvers` are configured.
- Normalize bracketed IPv6 URL literals before allow-list/IP checks so they are intentionally classified as IP addresses instead of falling into DNS.
- Add regression tests for custom resolver IPv4+IPv6 aggregation, IPv6-only private host blocking, IPv6-only public host allowance, and IPv6 literal handling without DNS lookup.

## Security assessment
The disclosure identifies a real security correctness bug in the custom DNS resolver path: it queried only A records via `resolve4()`, while the default system lookup path returned both IPv4 and IPv6 addresses. This meant an IPv6-only private hostname could throw a DNS-style error instead of being classified with the existing `URL uses a private hostname` security error.

The impact is conditional rather than an unconditional SSRF bypass. `isSafeURL()` failed closed by throwing, so exploitability depends on downstream callers treating DNS exceptions as non-security failures and proceeding with the outbound request anyway. Because of that, this is worth fixing as a security boundary correctness issue, but it is a weak CVE candidate and should not be described as a clean bypass in `url-sheriff` itself.

Suggested scope/severity language: low to medium, conditional on custom `dnsResolvers` usage plus unsafe fail-open exception handling by the consuming application.

## Tests
- `npm test`
- `npm run build`
- `npm run lint`
