### PR TITLE
fix: support TypeScript 6 declaration builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lint-staged": "^16.0.0",
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
-        "typescript": "^5.8.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.0",
         "validate-conventional-commit": "^1.0.4"
       },
@@ -5269,9 +5269,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lint-staged": "^16.0.0",
     "ts-node": "^10.9.2",
     "tsup": "^8.4.0",
-    "typescript": "^5.8.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",
     "validate-conventional-commit": "^1.0.4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,11 @@
     "module": "NodeNext",
     "target": "ES2022",
     "ignoreDeprecations": "6.0",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
     "noEmit": true,
     "rootDir": "./src",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,11 +13,7 @@
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "target": "ES2022",
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
-    },
+    "ignoreDeprecations": "6.0",
     "noEmit": true,
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION
TypeScript 6 treats the tsup declaration build baseUrl option as deprecated. Align the project with TypeScript 6 and suppress this deprecation while retaining the existing build configuration. The lockfile was regenerated and npm run build passes in Node 24.