### PR TITLE
fix: enforce secure URL defaults

### DIFF
--- a/.changeset/secure-url-defaults.md
+++ b/.changeset/secure-url-defaults.md
@@ -1,0 +1,5 @@
+---
+"url-sheriff": major
+---
+
+Default URL validation to HTTP and HTTPS, reject hostless URLs and empty DNS results, and make empty or cleared scheme configuration restore the secure defaults.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ npm install --save url-sheriff
 ```js
 import URLSheriff from 'url-sheriff'
 
-// initialize
 const sheriff = new URLSheriff()
 
-// this will throw an Error exception
-sheriff.isSafeURL('http://127.0.0.1:3000')
+await sheriff.isSafeURL('https://example.com') // true
+
+// Throws `URL uses a private hostname`
+await sheriff.isSafeURL('http://127.0.0.1:3000')
 ```
+
+### Secure Defaults
+
+URL Sheriff allows only `http` and `https` URLs by default. A URL being accepted by `new URL()` means it is syntactically valid; it does not mean the URL is safe for a server to access. Hostless URLs and hostnames that resolve to no IP addresses are rejected because URL Sheriff cannot establish a safe network destination.
+
+Scheme checks are applied before hostname, allow-list, and IP-address validation. Configure every additional scheme explicitly and ensure the downstream client is safe for that scheme.
 
 ### Using Custom DNS Resolvers
 
@@ -94,7 +101,8 @@ const currentAllowList = sheriff.getAllowList()
 3. If the hostname doesn't match any entry in the allow-list, the normal safety checks proceed:
    - Check if the hostname is a valid IP address and if it's private
    - Resolve the hostname to IP addresses and check if any are private
-4. Additionally, if any of the resolved IP addresses match entries in the allow-list, the URL is considered safe.
+
+Resolved IP addresses are always checked for private ranges. They are not matched against the allow-list.
 
 ### Debug Logging
 
@@ -124,38 +132,46 @@ This can be helpful for:
 
 ### Allowed Schemes
 
-Initialize with allowed schemes
+The effective default is always `['http', 'https']`:
+
+```js
+const sheriff = new URLSheriff()
+
+sheriff.getAllowedSchemes() // ['http', 'https']
+```
+
+Opt in to additional schemes explicitly:
 
 ```js
 const sheriff = new URLSheriff({
-  allowedSchemes: ['https', 'http']
-});
+  allowedSchemes: ['http', 'https', 'ftp']
+})
+
+await sheriff.isSafeURL('ftp://example.com') // true when the host resolves publicly
 ```
 
-Or set allowed schemes after initialization
+Schemes are matched case-insensitively. Passing an empty list or calling `clearSchemeRestrictions()` restores the secure HTTP/HTTPS defaults:
 
 ```js
-sheriff.setAllowedSchemes(['https']);
+sheriff.setAllowedSchemes([])
+sheriff.getAllowedSchemes() // ['http', 'https']
+
+sheriff.setAllowedSchemes(['ftp'])
+sheriff.clearSchemeRestrictions()
+sheriff.getAllowedSchemes() // ['http', 'https']
 ```
 
-Check if a URL is safe
+Explicitly enabling a scheme does not bypass hostname validation. Hostless URLs such as `file:///etc/passwd` are rejected because there is no network destination to validate. DNS resolution must also return at least one address before a URL can be considered safe.
 
-```js
-await sheriff.isSafeURL('https://example.com'); // This will pass
-await sheriff.isSafeURL('ftp://example.com');   // This will throw an error
-```
+#### Migrating from 1.x
 
-Get current allowed schemes
+Version 2.0.0 changes scheme handling to fail closed:
 
-```js
-const schemes = sheriff.getAllowedSchemes(); // Returns ['https']
-```
-
-Remove all scheme restrictions
-
-```js
-sheriff.clearSchemeRestrictions();
-```
+- Unconfigured instances allow HTTP and HTTPS instead of every scheme.
+- Consumers that require FTP or another scheme must add it to `allowedSchemes` explicitly.
+- `allowedSchemes: []` and `clearSchemeRestrictions()` restore HTTP/HTTPS defaults instead of allowing every scheme.
+- `getAllowedSchemes()` returns the effective list instead of `null`.
+- Hostless URLs and hostnames resolving to no addresses now throw errors instead of returning `true`.
 
 ## References and Prior work
 

--- a/__tests__/allowedSchemes.test.ts
+++ b/__tests__/allowedSchemes.test.ts
@@ -17,7 +17,7 @@ describe('URL Scheme Restrictions Tests', () => {
     assert.strictEqual(isSafeHttps, true, 'Upper-case HTTPS should match lower-case HTTPS in the allowed schemes list')
   })
 
-  test('Should allow all URL schemes by default', async () => {
+  test('Should allow only HTTP and HTTPS schemes by default', async () => {
     // Arrange
     const sheriff = new URLSheriff()
     
@@ -28,8 +28,24 @@ describe('URL Scheme Restrictions Tests', () => {
     const isSafeHttps = await sheriff.isSafeURL('https://example.com')
     assert.strictEqual(isSafeHttps, true, 'HTTPS scheme should be allowed by default')
     
+    await assert.rejects(
+      sheriff.isSafeURL('ftp://example.com'),
+      {
+        name: 'Error',
+        message: "URL scheme 'ftp' is not allowed"
+      },
+      'FTP scheme should be rejected by default'
+    )
+  })
+
+  test('Should allow explicitly configured additional schemes', async () => {
+    const sheriff = new URLSheriff({
+      allowedSchemes: ['HTTPS', 'ftp']
+    })
+
+    assert.deepStrictEqual(sheriff.getAllowedSchemes(), ['https', 'ftp'])
     const isSafeFtp = await sheriff.isSafeURL('ftp://example.com')
-    assert.strictEqual(isSafeFtp, true, 'FTP scheme should be allowed by default')
+    assert.strictEqual(isSafeFtp, true, 'Explicitly configured FTP should be allowed')
   })
 
   test('Should allow URLs with schemes in the allowed schemes list', async () => {
@@ -76,9 +92,9 @@ describe('URL Scheme Restrictions Tests', () => {
     // Arrange
     const sheriff = new URLSheriff()
     
-    // Initially all schemes should be allowed
-    const initialIsSafe = await sheriff.isSafeURL('ftp://example.com')
-    assert.strictEqual(initialIsSafe, true, 'All schemes should be allowed initially')
+    // Secure defaults should be active initially
+    const initialIsSafe = await sheriff.isSafeURL('http://example.com')
+    assert.strictEqual(initialIsSafe, true, 'HTTP should be allowed initially')
     
     // Act - restrict to HTTPS only
     sheriff.setAllowedSchemes(['https'])
@@ -110,7 +126,7 @@ describe('URL Scheme Restrictions Tests', () => {
     assert.deepStrictEqual(allowedSchemes, ['http', 'https'], 'Should return the configured allowed schemes')
   })
 
-  test('Should return null for allowed schemes when all schemes are allowed', () => {
+  test('Should return secure defaults when no allowed schemes are configured', () => {
     // Arrange
     const sheriff = new URLSheriff()
     
@@ -118,7 +134,16 @@ describe('URL Scheme Restrictions Tests', () => {
     const allowedSchemes = sheriff.getAllowedSchemes()
     
     // Assert
-    assert.strictEqual(allowedSchemes, null, 'Should return null when all schemes are allowed')
+    assert.deepStrictEqual(allowedSchemes, ['http', 'https'], 'Should return the secure default schemes')
+  })
+
+  test('Should return a defensive copy of allowed schemes', () => {
+    const sheriff = new URLSheriff()
+    const allowedSchemes = sheriff.getAllowedSchemes()
+
+    allowedSchemes.push('ftp')
+
+    assert.deepStrictEqual(sheriff.getAllowedSchemes(), ['http', 'https'])
   })
 
   test('Should clear scheme restrictions', async () => {
@@ -144,8 +169,16 @@ describe('URL Scheme Restrictions Tests', () => {
     const isSafeHttp = await sheriff.isSafeURL('http://example.com')
     assert.strictEqual(isSafeHttp, true, 'HTTP scheme should be allowed after clearing restrictions')
     
-    const isSafeFtp = await sheriff.isSafeURL('ftp://example.com')
-    assert.strictEqual(isSafeFtp, true, 'FTP scheme should be allowed after clearing restrictions')
+    await assert.rejects(
+      sheriff.isSafeURL('ftp://example.com'),
+      {
+        name: 'Error',
+        message: "URL scheme 'ftp' is not allowed"
+      },
+      'FTP scheme should be rejected after restoring secure defaults'
+    )
+
+    assert.deepStrictEqual(sheriff.getAllowedSchemes(), ['http', 'https'])
   })
 
   test('Should always check for private IP addresses even with allowed schemes', async (t) => {
@@ -222,7 +255,7 @@ describe('URL Scheme Restrictions Tests', () => {
     assert.strictEqual(isPrivateIPAddressMock.mock.callCount(), 0, 'isPrivateIPAddress should not be called for hosts in allow list')
   })
 
-  test('Should handle empty allowed schemes array as allowing all schemes', async () => {
+  test('Should handle empty allowed schemes array by restoring secure defaults', async () => {
     // Arrange
     const sheriff = new URLSheriff({
       allowedSchemes: []
@@ -234,5 +267,16 @@ describe('URL Scheme Restrictions Tests', () => {
     
     const isSafeHttps = await sheriff.isSafeURL('https://example.com')
     assert.strictEqual(isSafeHttps, true, 'HTTPS scheme should be allowed with empty allowed schemes array')
+
+    await assert.rejects(
+      sheriff.isSafeURL('ftp://example.com'),
+      {
+        name: 'Error',
+        message: "URL scheme 'ftp' is not allowed"
+      },
+      'FTP scheme should be rejected with an empty allowed schemes array'
+    )
+
+    assert.deepStrictEqual(sheriff.getAllowedSchemes(), ['http', 'https'])
   })
 })

--- a/__tests__/isSafeURL.sanity.test.ts
+++ b/__tests__/isSafeURL.sanity.test.ts
@@ -75,6 +75,36 @@ describe('SSRF isSafeURL Sanity suite #1', () => {
     assert.strictEqual(hostnameLookupMock.mock.callCount(), 0, 'hostnameLookup should not be called for IPv6 literals')
   })
 
+  test('If an explicitly allowed scheme has no hostname, an exception is thrown before lookup', async (t) => {
+    const sheriff = new URLSheriff({ allowedSchemes: ['file'] })
+    const hostnameLookupMock = t.mock.method(sheriff, 'hostnameLookup', async () => {
+      assert.fail('Hostless URLs must be rejected before DNS lookup')
+    })
+
+    await assert.rejects(
+      sheriff.isSafeURL('file:///etc/passwd'),
+      {
+        name: 'Error',
+        message: 'URL must include a hostname'
+      }
+    )
+
+    assert.strictEqual(hostnameLookupMock.mock.callCount(), 0)
+  })
+
+  test('If hostname resolution returns no addresses, an exception is thrown', async (t) => {
+    const sheriff = new URLSheriff()
+    t.mock.method(sheriff, 'hostnameLookup', async () => [])
+
+    await assert.rejects(
+      sheriff.isSafeURL('https://example.com'),
+      {
+        name: 'Error',
+        message: 'Could not resolve hostname: example.com'
+      }
+    )
+  })
+
   test.skip('If a URL uses an IPv4 Mapped address via IPv6 that turns out to be reserved, throw the exception', async (t) => {
     // this doesn't yet pass because it the ipv6 address doesn't get passed through new URL() anyway
 

--- a/docs/superpowers/plans/2026-08-06-secure-url-defaults.md
+++ b/docs/superpowers/plans/2026-08-06-secure-url-defaults.md
@@ -1,0 +1,313 @@
+# Secure URL Defaults Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make URL Sheriff fail closed for schemes, hostnames, and DNS results that cannot be safely validated, and prepare the breaking behavior for a 2.0.0 release.
+
+**Architecture:** Store an effective scheme allow-list on every `URLSheriff` instance, initialized from immutable HTTP/HTTPS defaults. Validate scheme and hostname before allow-list/IP handling, then enforce a non-empty result after either DNS resolution path so every affirmative result has passed a concrete safety check.
+
+**Tech Stack:** TypeScript, Node.js 24 test runner, `ts-node`, Changesets, npm
+
+## Global Constraints
+
+- The default and reset scheme list is exactly `['http', 'https']`.
+- Explicit non-empty `allowedSchemes` values remain supported and case-insensitive.
+- Empty hostnames are rejected before allow-list matching.
+- Empty DNS results are rejected after either resolver path.
+- No new runtime dependency is introduced.
+- The change is recorded as a major Changesets release; package versions are not manually published from this branch.
+- Preserve the pre-existing unstaged `package-lock.json` change and do not include it unless a task explicitly requires it.
+
+---
+
+### Task 1: Secure scheme defaults
+
+**Files:**
+- Modify: `__tests__/allowedSchemes.test.ts`
+- Modify: `src/main.ts`
+
+**Interfaces:**
+- Consumes: `URLSheriffConfig.allowedSchemes?: string[]`
+- Produces: `setAllowedSchemes(schemes: string[]): string[]`, `getAllowedSchemes(): string[]`, and `clearSchemeRestrictions(): void` with effective HTTP/HTTPS defaults
+
+- [ ] **Step 1: Replace permissive-default tests with secure-default expectations**
+
+Update `__tests__/allowedSchemes.test.ts` so default construction allows HTTP and HTTPS but rejects FTP:
+
+```ts
+test('Should allow only HTTP and HTTPS schemes by default', async () => {
+  const sheriff = new URLSheriff()
+
+  assert.strictEqual(await sheriff.isSafeURL('http://example.com'), true)
+  assert.strictEqual(await sheriff.isSafeURL('https://example.com'), true)
+  await assert.rejects(sheriff.isSafeURL('ftp://example.com'), {
+    name: 'Error',
+    message: "URL scheme 'ftp' is not allowed"
+  })
+})
+```
+
+Change the getter test to expect `['http', 'https']`. Change the empty-array and clear tests to verify they restore those defaults and reject FTP. Add an explicit opt-in test:
+
+```ts
+test('Should allow explicitly configured additional schemes', async () => {
+  const sheriff = new URLSheriff({ allowedSchemes: ['HTTPS', 'ftp'] })
+
+  assert.deepStrictEqual(sheriff.getAllowedSchemes(), ['https', 'ftp'])
+  assert.strictEqual(await sheriff.isSafeURL('ftp://example.com'), true)
+})
+```
+
+Add a defensive-copy assertion by mutating the array returned from `getAllowedSchemes()` and confirming a later call still returns `['http', 'https']`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `node --loader ts-node/esm --test __tests__/allowedSchemes.test.ts`
+
+Expected: FAIL because default FTP is currently allowed, default getter returns `null`, and reset operations currently remove all restrictions.
+
+- [ ] **Step 3: Implement effective secure defaults**
+
+In `src/main.ts`, add the module constant and make instance state non-nullable:
+
+```ts
+const DEFAULT_ALLOWED_SCHEMES = ['http', 'https'] as const
+
+#allowedSchemes: string[]
+```
+
+Initialize with a copied default when configuration is omitted:
+
+```ts
+this.#allowedSchemes = typeof config.allowedSchemes === 'undefined'
+  ? [...DEFAULT_ALLOWED_SCHEMES]
+  : this.setAllowedSchemes(config.allowedSchemes)
+```
+
+Make the scheme check unconditional and make empty/reset operations copy the defaults:
+
+```ts
+#isSchemeAllowed(scheme: string): boolean {
+  return this.#allowedSchemes.includes(scheme.toLowerCase())
+}
+
+setAllowedSchemes(schemes: string[]): string[] {
+  this.#allowedSchemes = schemes.length === 0
+    ? [...DEFAULT_ALLOWED_SCHEMES]
+    : schemes.map(scheme => scheme.toLowerCase())
+  return [...this.#allowedSchemes]
+}
+
+getAllowedSchemes(): string[] {
+  return [...this.#allowedSchemes]
+}
+
+clearSchemeRestrictions(): void {
+  this.#allowedSchemes = [...DEFAULT_ALLOWED_SCHEMES]
+}
+```
+
+Update adjacent comments and debug conditions so they describe effective allowed schemes rather than unrestricted/null state.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `node --loader ts-node/esm --test __tests__/allowedSchemes.test.ts`
+
+Expected: all allowed-scheme tests pass.
+
+- [ ] **Step 5: Commit the scheme-default change**
+
+Stage only `src/main.ts` and `__tests__/allowedSchemes.test.ts`.
+
+Commit: `fix: default to secure URL schemes`
+
+---
+
+### Task 2: Fail closed for missing hosts and addresses
+
+**Files:**
+- Modify: `__tests__/isSafeURL.sanity.test.ts`
+- Modify: `src/main.ts`
+
+**Interfaces:**
+- Consumes: normalized `URL.hostname`, `hostnameLookup(hostname): Promise<string[]>`, and `resolveHostnameViaServers(hostname): Promise<string[]>`
+- Produces: rejection with `URL must include a hostname` or `Could not resolve hostname: <hostname>` when validation evidence is absent
+
+- [ ] **Step 1: Add failing host and address regression tests**
+
+Add these behaviors to `__tests__/isSafeURL.sanity.test.ts`:
+
+```ts
+test('If an explicitly allowed scheme has no hostname, an exception is thrown before lookup', async (t) => {
+  const sheriff = new URLSheriff({ allowedSchemes: ['file'] })
+  const hostnameLookupMock = t.mock.method(sheriff, 'hostnameLookup', async () => {
+    assert.fail('Hostless URLs must be rejected before DNS lookup')
+  })
+
+  await assert.rejects(sheriff.isSafeURL('file:///etc/passwd'), {
+    name: 'Error',
+    message: 'URL must include a hostname'
+  })
+  assert.strictEqual(hostnameLookupMock.mock.callCount(), 0)
+})
+
+test('If hostname resolution returns no addresses, an exception is thrown', async (t) => {
+  const sheriff = new URLSheriff()
+  t.mock.method(sheriff, 'hostnameLookup', async () => [])
+
+  await assert.rejects(sheriff.isSafeURL('https://example.com'), {
+    name: 'Error',
+    message: 'Could not resolve hostname: example.com'
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `node --loader ts-node/esm --test __tests__/isSafeURL.sanity.test.ts`
+
+Expected: the hostless test returns `true`, and the empty-resolution test returns `true`.
+
+- [ ] **Step 3: Implement fail-closed invariants**
+
+After scheme validation and before allow-list validation in `isSafeURL()`:
+
+```ts
+if (hostname.length === 0) {
+  debug('URL does not include a hostname')
+  throw new Error('URL must include a hostname')
+}
+```
+
+After the resolver branch and before private-address iteration:
+
+```ts
+if (ipAddressList.length === 0) {
+  debug('Hostname did not resolve to any IP addresses: %s', hostname)
+  throw new Error(`Could not resolve hostname: ${hostname}`)
+}
+```
+
+- [ ] **Step 4: Run focused and related resolver tests and verify GREEN**
+
+Run: `node --loader ts-node/esm --test __tests__/isSafeURL.sanity.test.ts __tests__/customResolver.test.ts`
+
+Expected: all sanity and custom-resolver tests pass.
+
+- [ ] **Step 5: Commit the fail-closed validation change**
+
+Stage only `src/main.ts` and `__tests__/isSafeURL.sanity.test.ts`.
+
+Commit: `fix: reject URLs without verifiable hosts`
+
+---
+
+### Task 3: Document the breaking security behavior
+
+**Files:**
+- Modify: `README.md`
+- Create: `.changeset/secure-url-defaults.md`
+
+**Interfaces:**
+- Consumes: the final public behavior from Tasks 1 and 2
+- Produces: consumer migration guidance and a major-release Changesets entry
+
+- [ ] **Step 1: Rewrite README usage around the secure default**
+
+Update Basic Usage to await the call and show both a public HTTPS URL and rejected private URL. Add a security-default explanation stating:
+
+```md
+URL Sheriff allows only `http` and `https` URLs by default. A URL being accepted by `new URL()` means it is syntactically valid; it does not mean the URL is safe for a server to access. Hostless URLs and hostnames that resolve to no IP addresses are rejected because URL Sheriff cannot establish a safe network destination.
+```
+
+Replace the stale resolved-IP allow-list step with documentation matching the current hostname-only short circuit.
+
+Rewrite Allowed Schemes to show explicit opt-in:
+
+```js
+const sheriff = new URLSheriff({
+  allowedSchemes: ['http', 'https', 'ftp']
+})
+```
+
+Document that `allowedSchemes: []` and `clearSchemeRestrictions()` restore HTTP/HTTPS defaults. Add a 1.x migration note explaining that consumers needing other schemes must list them explicitly and that hostless schemes are no longer accepted.
+
+- [ ] **Step 2: Add the major Changesets entry**
+
+Create `.changeset/secure-url-defaults.md`:
+
+```md
+---
+"url-sheriff": major
+---
+
+Default URL validation to HTTP and HTTPS, reject hostless URLs and empty DNS results, and make empty or cleared scheme configuration restore the secure defaults.
+```
+
+- [ ] **Step 3: Review documentation against implemented behavior**
+
+Run: `rg -n -C 3 "allow-list|Allowed Schemes|allowedSchemes|hostless|resolve" README.md`
+
+Expected: no claim remains that resolved IPs are allow-listed; defaults and migration behavior match the tests.
+
+- [ ] **Step 4: Commit documentation and release metadata**
+
+Stage only `README.md` and `.changeset/secure-url-defaults.md`.
+
+Commit: `docs: explain secure URL validation defaults`
+
+---
+
+### Task 4: Verify and publish the branch
+
+**Files:**
+- Verify: all committed files in this plan
+- Preserve unstaged: `package-lock.json`
+
+**Interfaces:**
+- Consumes: completed implementation and documentation commits
+- Produces: a pushed branch and draft GitHub pull request targeting the default branch
+
+- [ ] **Step 1: Run all project checks from a fresh state**
+
+Run each command and require exit code 0:
+
+```sh
+npm test
+npm run lint
+npm run build
+```
+
+- [ ] **Step 2: Inspect final scope and history**
+
+Run:
+
+```sh
+git status -sb
+git diff origin/main...HEAD --stat
+git log --oneline origin/main..HEAD
+```
+
+Expected: only the design, plan, tests, implementation, README, and Changesets entry are committed; the pre-existing `package-lock.json` change remains unstaged.
+
+- [ ] **Step 3: Verify GitHub CLI authentication**
+
+Run: `gh --version`
+
+Run: `gh auth status`
+
+Expected: GitHub CLI is installed and authenticated for `github.com`.
+
+- [ ] **Step 4: Push the feature branch**
+
+Run: `git push -u origin work/secure-url-defaults`
+
+Expected: the branch tracks `origin/work/secure-url-defaults`.
+
+- [ ] **Step 5: Open a draft pull request**
+
+Create a draft PR targeting `main` with title `fix: enforce secure URL defaults`. The body must summarize the vulnerability root cause, new HTTP/HTTPS default, explicit migration path, breaking-change/major-release impact, and exact verification commands.
+
+- [ ] **Step 6: Report publication details**
+
+Provide the branch, commit list, PR URL, checks, and note that `package-lock.json` remains a pre-existing unstaged change outside the PR.

--- a/docs/superpowers/specs/2026-08-06-secure-url-defaults-design.md
+++ b/docs/superpowers/specs/2026-08-06-secure-url-defaults-design.md
@@ -1,0 +1,62 @@
+# Secure URL Defaults Design
+
+## Summary
+
+URL Sheriff 1.x allows every URL scheme unless consumers configure `allowedSchemes`. A hostless URL such as `file:///etc/passwd` therefore reaches the system DNS lookup with an empty hostname. Node.js can resolve that lookup to an empty address list, which the current private-address check interprets as safe.
+
+Version 2.0.0 will fail closed at both policy boundaries involved in this behavior: it will allow only HTTP and HTTPS by default, and it will reject URLs for which no hostname or no resolved address can be validated.
+
+## Public behavior
+
+- Constructing `new URLSheriff()` permits only `http` and `https` schemes.
+- Passing `allowedSchemes` explicitly permits exactly the listed schemes, normalized case-insensitively.
+- Passing `allowedSchemes: []` resets the instance to the secure `http` and `https` defaults.
+- Calling `clearSchemeRestrictions()` resets the instance to the secure `http` and `https` defaults. The method name remains unchanged for compatibility, but its documentation will explain the new reset behavior.
+- Calling `getAllowedSchemes()` returns the effective scheme list. Under default configuration it returns `['http', 'https']` rather than `null`.
+- Consumers that require another network scheme must opt in explicitly, for example `allowedSchemes: ['http', 'https', 'ftp']`.
+- A parsed URL with an empty hostname is rejected before allow-list matching or address validation, even when its scheme was explicitly enabled.
+- A DNS resolution that produces no addresses is rejected rather than treated as proof that no private address exists.
+
+These changes are intentionally breaking and require a major release.
+
+## Implementation
+
+`src/main.ts` will define one immutable default scheme list containing `http` and `https`. Each instance will receive its own copied array so callers cannot mutate shared defaults through returned values.
+
+Scheme validation will always operate on an effective string array instead of using `null` to represent unrestricted access. `setAllowedSchemes([])` and `clearSchemeRestrictions()` will copy the defaults into instance state. Explicit non-empty lists remain supported and case-insensitive.
+
+`isSafeURL()` will preserve the existing validation order for schemes, then reject an empty normalized hostname before checking the allow-list. This prevents an allow-list expression that matches the empty string from approving hostless URLs.
+
+After either the system or custom DNS path returns, `isSafeURL()` will enforce a shared non-empty-address invariant. The existing custom resolver guard remains useful, while the shared check protects the system resolver and any future resolver implementation.
+
+The errors will remain exceptions, matching the current API:
+
+- Disallowed scheme: `URL scheme '<scheme>' is not allowed`
+- Missing hostname: `URL must include a hostname`
+- Empty resolution: `Could not resolve hostname: <hostname>`
+
+## Tests
+
+Tests will be written before production changes and observed failing for the expected reasons. Coverage will include:
+
+- HTTP and HTTPS are allowed by default.
+- FTP and `file` are rejected by default.
+- An explicitly listed additional scheme remains usable when it has a hostname.
+- `allowedSchemes: []` restores HTTP/HTTPS defaults.
+- `clearSchemeRestrictions()` restores HTTP/HTTPS defaults.
+- `getAllowedSchemes()` reports the effective defaults and returns a defensive copy.
+- A hostless URL is rejected even when `file` is explicitly listed.
+- A mocked system lookup returning an empty address list is rejected.
+- Existing private-address, custom-resolver, and allow-list behavior remains covered by the full suite.
+
+## Documentation and release
+
+The README will state that URL parsing only establishes syntactic validity and does not make a URL safe to fetch. It will document the HTTP/HTTPS defaults, explicit opt-in for additional schemes, rejection of hostless URLs, empty-resolution fail-closed behavior, and migration examples for 1.x consumers.
+
+The stale README statement claiming that resolved IP addresses are checked against the allow-list will be removed because that behavior was already removed from the implementation as a security fix.
+
+A Changesets entry will mark `url-sheriff` for a major release and summarize the secure-default migration. The Changesets release workflow will use that entry to produce version 2.0.0; the implementation PR will not manually run the release/version command.
+
+## Scope boundaries
+
+This change does not attempt to solve DNS rebinding inherent in check-then-connect APIs, provide a fetching client or custom agent, or classify the safety semantics of every explicitly enabled non-HTTP scheme. It establishes secure defaults and ensures URL Sheriff never returns `true` when there is no hostname or resolved address to validate.

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { debuglog } from 'node:util'
 
 // Initialize debug logger for 'url-sheriff' namespace
 const debug = debuglog('url-sheriff')
+const DEFAULT_ALLOWED_SCHEMES = ['http', 'https'] as const
 
 function normalizeHostname(hostname: string): string {
   if (hostname.startsWith('[') && hostname.endsWith(']')) {
@@ -33,16 +34,14 @@ export default class URLSheriff {
   #config: URLSheriffConfig
   #resolver?: Resolver
   #allowList: Array<string | RegExp>
-  #allowedSchemes: string[] | null // Store allowed schemes
+  #allowedSchemes: string[]
 
   constructor(config: URLSheriffConfig = {}) {
     this.#config = config
     this.#allowList = config.allowList || []
-    if (typeof config.allowedSchemes !== 'undefined') {
-      this.#allowedSchemes = this.setAllowedSchemes(config.allowedSchemes)
-    } else {
-      this.#allowedSchemes = null
-    }
+    this.#allowedSchemes = typeof config.allowedSchemes === 'undefined'
+      ? [...DEFAULT_ALLOWED_SCHEMES]
+      : this.setAllowedSchemes(config.allowedSchemes)
 
     debug('Initializing URLSheriff with config: %O', this.#config)
     
@@ -56,9 +55,7 @@ export default class URLSheriff {
       debug('Initialized with allow-list entries: %d', this.#allowList.length)
     }
 
-    if (this.#allowedSchemes) {
-      debug('Initialized with allowed schemes: %O', this.#allowedSchemes)
-    }
+    debug('Initialized with allowed schemes: %O', this.#allowedSchemes)
   }
 
   #getParsedURL(url: string | URL): URL {
@@ -91,14 +88,9 @@ export default class URLSheriff {
    * Checks if the URL scheme is allowed based on configuration
    * 
    * @param scheme The URL scheme to check
-   * @returns boolean True if the scheme is allowed or if no scheme restrictions are set
+   * @returns boolean True if the scheme is allowed
    */
   #isSchemeAllowed(scheme: string): boolean {
-    // If no schemes are specified, all schemes are allowed
-    if (!this.#allowedSchemes || this.#allowedSchemes.length === 0) {
-      return true
-    }
-
     return this.#allowedSchemes.includes(scheme.toLowerCase())
   }
   #isInAllowList(value: string): boolean {
@@ -325,32 +317,29 @@ export default class URLSheriff {
    * @param schemes Array of allowed URL schemes (e.g., ['http', 'https'])
    * @returns string[] The updated allowed schemes
    */
-  setAllowedSchemes(schemes: string[]): string[] | null {
+  setAllowedSchemes(schemes: string[]): string[] {
     debug('Setting allowed schemes: %O', schemes)
-    if (schemes.length === 0) {
-      this.#allowedSchemes = null;
-      return null;
-    }
+    this.#allowedSchemes = schemes.length === 0
+      ? [...DEFAULT_ALLOWED_SCHEMES]
+      : schemes.map(scheme => scheme.toLowerCase())
 
-    this.#allowedSchemes = schemes.map(scheme => scheme.toLowerCase())
-
-    return this.#allowedSchemes;
+    return [...this.#allowedSchemes]
   }
 
   /**
    * Get the current allowed URL schemes
    * 
-   * @returns string[] | null The current allowed schemes or null if all schemes are allowed
+   * @returns string[] The effective allowed schemes
    */
-  getAllowedSchemes(): string[] | null {
-    return this.#allowedSchemes ? [...this.#allowedSchemes] : null
+  getAllowedSchemes(): string[] {
+    return [...this.#allowedSchemes]
   }
 
   /**
-   * Clear scheme restrictions
+   * Restore the secure default scheme restrictions
    */
   clearSchemeRestrictions(): void {
-    debug('Clearing scheme restrictions')
-    this.#allowedSchemes = null
+    debug('Restoring default scheme restrictions')
+    this.#allowedSchemes = [...DEFAULT_ALLOWED_SCHEMES]
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,11 @@ export default class URLSheriff {
       throw new Error(`URL scheme '${scheme}' is not allowed`)
     }
 
+    if (hostname.length === 0) {
+      debug('URL does not include a hostname')
+      throw new Error('URL must include a hostname')
+    }
+
     // Check if the hostname is in the allow-list
     if (this.#isInAllowList(hostname)) {
       debug('Hostname is in allow-list, URL is safe: %s', hostname)
@@ -164,6 +169,11 @@ export default class URLSheriff {
     } else {
       debug('Using system DNS resolver')
       ipAddressList = await this.hostnameLookup(hostname)
+    }
+
+    if (ipAddressList.length === 0) {
+      debug('Hostname did not resolve to any IP addresses: %s', hostname)
+      throw new Error(`Could not resolve hostname: ${hostname}`)
     }
     
     debug('Resolved hostname %s to IP addresses: %O', hostname, ipAddressList)


### PR DESCRIPTION
## Summary

- default URL validation to HTTP and HTTPS
- reject hostless URLs before allow-list and DNS handling
- reject empty DNS resolution results instead of treating them as safe
- document the breaking behavior and 1.x migration path
- add a Changesets entry for the 2.0.0 major release

## Root cause

Hostless URLs could reach the system DNS lookup with an empty hostname. Node.js may return an empty address list, and the private-address check treated that list as containing no private addresses, allowing the URL. In addition, all URL schemes were permitted by default unless consumers opted into restrictions.

## Breaking changes

- default schemes are now `http` and `https`
- `allowedSchemes: []` and `clearSchemeRestrictions()` restore those defaults
- `getAllowedSchemes()` returns the effective scheme list instead of `null`
- hostless URLs and empty DNS results reject
- additional schemes require explicit opt-in

## Validation

- `npm test` — 36 passed, 1 pre-existing skipped, 0 failed
- `npm run lint` — passed
- `npm run build` — passed
- `npx changeset status` — recognizes `url-sheriff` as a major bump
- `git diff --check origin/main...HEAD` — passed
